### PR TITLE
fixed logic wicc checking

### DIFF
--- a/WaykichainParams.go
+++ b/WaykichainParams.go
@@ -311,7 +311,7 @@ func abs(x int64) int64 {
 }
 
 func checkMoneyRange(value int64) bool {
-	return value >= 0 && value <= MAX_MONEY
+	return value > 0 && value <= MAX_MONEY
 }
 
 

--- a/WaykichainWallet.go
+++ b/WaykichainWallet.go
@@ -562,7 +562,7 @@ func SignCdpStakeTx(privateKey string, param *CdpStakeTxParam) (string, error) {
 
 	tx.TxType = commons.CDP_STAKE_TX
 	tx.Version = TX_VERSION
-	if  param.ScoinMint < 0 {
+	if  param.ScoinMint <= 0 {
 		return "", ERR_CDP_STAKE_NUMBER
 	}
 


### PR DESCRIPTION
Fixed simple logic bugs that were found during my test. 
TestCdpStakeTx function allowed 0 ScoindMint to go through.  Same issue with ScoindMint. Now they will give the user an error if he used 0 has a input amount.